### PR TITLE
(Optional) 'autoWireTasks' parameter for manual dependency specs 

### DIFF
--- a/src/main/groovy/com/madvay/tools/build/mixc/MixcModel.groovy
+++ b/src/main/groovy/com/madvay/tools/build/mixc/MixcModel.groovy
@@ -26,6 +26,8 @@ class MixcModel {
 
     boolean debugEnabled = true
     boolean releaseEnabled = true
+    /** if set to 'false', task dependency will not be created and can instead be configured in the build script */
+    boolean autoWireTasks = true
 
     List<String> nativeProjects = []
     List<String> j2objcProjects = []

--- a/src/main/groovy/com/madvay/tools/build/mixc/MixcPlugin.groovy
+++ b/src/main/groovy/com/madvay/tools/build/mixc/MixcPlugin.groovy
@@ -40,6 +40,7 @@ class MixcPlugin extends RuleSource implements Plugin<Project> {
                     @Path("mixc") MixcModel mixcConfig) {
         boolean debugEnabled = mixcConfig.debugEnabled
         boolean releaseEnabled = mixcConfig.releaseEnabled
+        boolean autoWireTasks = mixcConfig.autoWireTasks
 
         // Prebuild phase.  We need all native builds (whether j2objc or custom) to occur
         // before our own xcode builds.
@@ -110,9 +111,11 @@ class MixcPlugin extends RuleSource implements Plugin<Project> {
                 enabled = releaseEnabled
             }
 
-            tasks.get('assemble').dependsOn(
-                    "xcode${nameFirstUpper}BuildDebug",
-                    "xcode${nameFirstUpper}BuildRelease")
+            if (autoWireTasks) {
+                tasks.get('assemble').dependsOn(
+                        "xcode${nameFirstUpper}BuildDebug",
+                        "xcode${nameFirstUpper}BuildRelease")
+            }
 
             tasks.create "xcode${nameFirstUpper}ArchiveRelease", XcodeBuildTask, {
                 config = 'Release'
@@ -187,9 +190,11 @@ class MixcPlugin extends RuleSource implements Plugin<Project> {
                 enabled = releaseEnabled
             }
 
-            tasks.get('clean').dependsOn(
-                    "xcode${nameFirstUpper}CleanDebug",
-                    "xcode${nameFirstUpper}CleanRelease")
+            if (autoWireTasks) {
+                tasks.get('clean').dependsOn(
+                        "xcode${nameFirstUpper}CleanDebug",
+                        "xcode${nameFirstUpper}CleanRelease")
+            }
 
             if (val.testTarget != null) {
                 tasks.create "xcode${nameFirstUpper}TestDebug", XcodeBuildTask, {
@@ -222,9 +227,11 @@ class MixcPlugin extends RuleSource implements Plugin<Project> {
                     enabled = releaseEnabled
                 }
 
-                tasks.get('check').dependsOn(
-                        "xcode${nameFirstUpper}TestDebug",
-                        "xcode${nameFirstUpper}TestRelease")
+                if (autoWireTasks) {
+                    tasks.get('check').dependsOn(
+                            "xcode${nameFirstUpper}TestDebug",
+                            "xcode${nameFirstUpper}TestRelease")
+                }
             }
         }
 


### PR DESCRIPTION
Added 'autoWireTasks' parameter to support manual dependency specs when used in combination with other plugins.

This is useful when combining several plugins that require steps to be performed before the iOS compilation (e.g. when combining with https://github.com/zasadnyy/unity-gradle-plugin)
